### PR TITLE
Break into executables per builder convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-  - ERLANG_VERSION=18.2.1
+  - ERLANG_VERSION=18.2
 
 before_install:
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-  - ERLANG_VERSION=18.1
+  - ERLANG_VERSION=18.0
 
 before_install:
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-  - ERLANG_VERSION=18.2
+  - ERLANG_VERSION=18.1
 
 before_install:
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
 before_install:
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")
   - export RELEASE=$(lsb_release -rs 2>/dev/null || sw_vers -productVersion | sed 's/^\([0-9][0-9]*.[0-9][0-9]*\).*/\1/')
-  - export TARGET_DIR=$HOME/archive/binaries/$OS_NAME/${RELEASE}/$(uname -m)
-  - mkdir -p $TARGET_DIR
+  - export TARGET_DIR=${TRAVIS_BUILD_DIR}/${OS_NAME}/${RELEASE}/$(uname -m)
+  - mkdir -p ${TARGET_DIR}
 
 install:
   - true
@@ -31,6 +31,6 @@ after_success: ./bin/archive
 addons:
   artifacts:
     paths:
-    - '${TARGET_DIR}/'
+    - '${OS_NAME}'
     target_paths:
     - '/binaries/${OS_NAME}/${LSB_RELEASE}/${ARCH}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,16 @@ matrix:
       dist: trusty
       group: edge
       env:
-        - RELEASE=trusty
+      - DIST=trusty
     - sudo: required
       env:
-        - RELEASE=precise
+      - DIST=precise
 
 env:
   global:
-    - ERLANG_VERSION=18.2.1
+  - ERLANG_VERSION=18.2.1
 
 before_install:
-  - kerl update releases
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")
   - export RELEASE=$(lsb_release -rs 2>/dev/null || sw_vers -productVersion | sed 's/^\([0-9][0-9]*.[0-9][0-9]*\).*/\1/')
   - export TARGET_DIR=$HOME/archive/binaries/$OS_NAME/${RELEASE}/$(uname -m)
@@ -25,22 +24,13 @@ before_install:
 install:
   - true
 
-script:
-  - kerl build $ERLANG_VERSION $ERLANG_VERSION
-  - kerl install $ERLANG_VERSION $HOME/otp/$ERLANG_VERSION
-  - source $HOME/otp/$ERLANG_VERSION/activate
+script: ./bin/compile
 
+after_success: ./bin/archive
 
-after_success:
-  - pushd $HOME/otp
-  - tar cjvf ${TARGET_DIR}/erlang-${ERLANG_VERSION}.tar.bz2 $ERLANG_VERSION
-  - popd
-
-deploy:
-  provider: s3
-  local_dir: $HOME/archive
-  skip_cleanup: true
-  bucket: travis-otp-releases
-  access_key_id: $ACCESS_KEY_ID
-  secret_access_key: $SECRET_ACCESS_KEY
-  acl: public_read
+addons:
+  artifacts:
+    paths:
+    - '${TARGET_DIR}/'
+    target_paths:
+    - '/binaries/${OS_NAME}/${LSB_RELEASE}/${ARCH}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-  - ERLANG_VERSION=18.0
+  - ERLANG_VERSION=18.2.1
 
 before_install:
   - export OS_NAME=$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")

--- a/bin/archive
+++ b/bin/archive
@@ -13,11 +13,15 @@ set -o errexit
 }
 
 cd "${HOME}/otp"
-tar -cjvf \
+tar -cjf \
   "${TARGET_DIR}/erlang-${ERLANG_VERSION}-nonroot.tar.bz2" \
   "${ERLANG_VERSION}"
 
+echo "Created ${TARGET_DIR}/erlang-${ERLANG_VERSION}-nonroot.tar.bz2"
+
 cd /
-tar -cjvf \
+tar -cjf \
   "${TARGET_DIR}/erlang-${ERLANG_VERSION}.tar.bz2" \
   "${HOME}/otp/${ERLANG_VERSION}"
+
+echo "Created ${TARGET_DIR}/erlang-${ERLANG_VERSION}.tar.bz2"

--- a/bin/archive
+++ b/bin/archive
@@ -12,15 +12,13 @@ set -o errexit
   exit 1
 }
 
-cd "${HOME}/otp"
-tar -cjf \
+tar -C "${HOME}/otp" -cjf \
   "${TARGET_DIR}/erlang-${ERLANG_VERSION}-nonroot.tar.bz2" \
   "${ERLANG_VERSION}"
 
 echo "Created ${TARGET_DIR}/erlang-${ERLANG_VERSION}-nonroot.tar.bz2"
 
-cd /
-tar -cjf \
+tar -C / -cjf \
   "${TARGET_DIR}/erlang-${ERLANG_VERSION}.tar.bz2" \
   "${HOME}/otp/${ERLANG_VERSION}"
 

--- a/bin/archive
+++ b/bin/archive
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+[[ ${ERLANG_VERSION} ]] || {
+  echo 'Missing $ERLANG_VERSION' >&2
+  exit 1
+}
+
+[[ ${TARGET_DIR} ]] || {
+  echo 'Missing $TARGET_DIR' >&2
+  exit 1
+}
+
+cd "${HOME}/otp"
+tar -cjvf \
+  "${TARGET_DIR}/erlang-${ERLANG_VERSION}-nonroot.tar.bz2" \
+  "${ERLANG_VERSION}"
+
+cd /
+tar -cjvf \
+  "${TARGET_DIR}/erlang-${ERLANG_VERSION}.tar.bz2" \
+  "${HOME}/otp/${ERLANG_VERSION}"

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+[[ ${ERLANG_VERSION} ]] || {
+  echo 'Missing $ERLANG_VERSION' >&2
+  exit 1
+}
+
+kerl update releases
+kerl build "${ERLANG_VERSION}" "${ERLANG_VERSION}"
+kerl install "${ERLANG_VERSION}" "${HOME}/otp/${ERLANG_VERSION}"


### PR DESCRIPTION
and archive/ship both "nonroot" and "root" versions.
